### PR TITLE
Simplify interfaces

### DIFF
--- a/applier.go
+++ b/applier.go
@@ -31,5 +31,5 @@ type RaftState struct {
 type Applier interface {
 
 	// Apply processes commit messages after being processed by Raft
-	Apply() chan Commit
+	Apply(Commit)
 }

--- a/cluster.go
+++ b/cluster.go
@@ -24,6 +24,9 @@ type ClusterChangeEvent struct {
 
 // Cluster maintains an active list of nodes in the cluster. Cluster is also responsible for reporting and responding to changes in cluster membership.
 type Cluster interface {
+	Notifier
+	Applier
+	Updater
 
 	// ID represents the cluster ID.
 	ID() uint64
@@ -37,15 +40,6 @@ type Cluster interface {
 	// IsBanished checks whether the given ID has been removed from this
 	// cluster at some point in the past.
 	IsBanished(id uint64) bool
-
-	// Notifier returns a ClusterChangeNotifier and is used to notify the Raft node of cluster changes.
-	Notifier() ClusterChangeNotifier
-
-	// Applier returns an Applier which processes Raft log events.
-	Applier() Applier
-
-	// ApplyChange is called after the ClusterChangeEvent has been processed and stored by Raft.
-	ApplyChange() chan ClusterChangeEvent
 
 	// LocalNode returns the RaftNode which represents the local node of the cluster.
 	LocalNode() RaftNode

--- a/config.go
+++ b/config.go
@@ -4,8 +4,6 @@ import "github.com/coreos/etcd/raft"
 
 // ClusterConfig helps to configure a RaftNode
 type ClusterConfig struct {
-	Name      string
-	Raft      raft.Config
-	Notifiers []ClusterChangeNotifier
-	Applier   Applier
+	Name string
+	Raft raft.Config
 }

--- a/notifier.go
+++ b/notifier.go
@@ -1,11 +1,44 @@
 package raftor
 
-// ClusterChangeNotifier notifies the receiver of the cluster change.
-type ClusterChangeNotifier interface {
+// Notifier notifies the receiver of the cluster change.
+type Notifier interface {
 
-	// Change returns a channel of ClusterChangeEvents which can be read when a node joins, leaves or is updated in the cluster.
-	Notify() <-chan ClusterChangeEvent
-
-	// Stop stops the notifier from sending out any more notifications.
-	Stop()
+	// Notify returns a read-only channel of ClusterChangeEvents which can be read when a node joins, leaves or is updated in the cluster.
+	Notify(ClusterChangeEvent)
 }
+
+// // NotifyChange sends ClusterChangeEvents over the given channel when a node joins, leaves or is updated in the cluster.
+// func (n *notifier) Notify(evt ClusterChangeEvent) <-chan ClusterChangeEvent {
+// 	return n.channel
+// }
+
+// // NotifyJoin is invoked when a node is detected to have joined.
+// // The Node argument must not be modified.
+// func (n *notifier) NotifyJoin(other *memberlist.Node) {
+// 	n.send(ClusterChangeEvent{
+// 		Type:   AddMember,
+// 		Member: NewMember(n.hash(other), other.Meta),
+// 	})
+// 	return
+// }
+
+// // NotifyLeave is invoked when a node is detected to have left.
+// // The Node argument must not be modified.
+// func (n *notifier) NotifyLeave(other *memberlist.Node) {
+// 	n.send(ClusterChangeEvent{
+// 		Type:   RemoveMember,
+// 		Member: NewMember(n.hash(other), other.Meta),
+// 	})
+// 	return
+// }
+
+// // NotifyUpdate is invoked when a node is detected to have
+// // updated, usually involving the meta data. The Node argument
+// // must not be modified.
+// func (n *notifier) NotifyUpdate(other *memberlist.Node) {
+// 	n.send(ClusterChangeEvent{
+// 		Type:   UpdateMember,
+// 		Member: NewMember(n.hash(other), other.Meta),
+// 	})
+// 	return
+// }

--- a/notifier.go
+++ b/notifier.go
@@ -6,39 +6,3 @@ type Notifier interface {
 	// Notify returns a read-only channel of ClusterChangeEvents which can be read when a node joins, leaves or is updated in the cluster.
 	Notify(ClusterChangeEvent)
 }
-
-// // NotifyChange sends ClusterChangeEvents over the given channel when a node joins, leaves or is updated in the cluster.
-// func (n *notifier) Notify(evt ClusterChangeEvent) <-chan ClusterChangeEvent {
-// 	return n.channel
-// }
-
-// // NotifyJoin is invoked when a node is detected to have joined.
-// // The Node argument must not be modified.
-// func (n *notifier) NotifyJoin(other *memberlist.Node) {
-// 	n.send(ClusterChangeEvent{
-// 		Type:   AddMember,
-// 		Member: NewMember(n.hash(other), other.Meta),
-// 	})
-// 	return
-// }
-
-// // NotifyLeave is invoked when a node is detected to have left.
-// // The Node argument must not be modified.
-// func (n *notifier) NotifyLeave(other *memberlist.Node) {
-// 	n.send(ClusterChangeEvent{
-// 		Type:   RemoveMember,
-// 		Member: NewMember(n.hash(other), other.Meta),
-// 	})
-// 	return
-// }
-
-// // NotifyUpdate is invoked when a node is detected to have
-// // updated, usually involving the meta data. The Node argument
-// // must not be modified.
-// func (n *notifier) NotifyUpdate(other *memberlist.Node) {
-// 	n.send(ClusterChangeEvent{
-// 		Type:   UpdateMember,
-// 		Member: NewMember(n.hash(other), other.Meta),
-// 	})
-// 	return
-// }

--- a/pkg/memberlist/notifier.go
+++ b/pkg/memberlist/notifier.go
@@ -7,74 +7,46 @@ import (
 	"github.com/hashicorp/memberlist"
 )
 
-// BlockingNotifier blocks until each event has been consumed. It also implements the memberlist.EventDelegate interface which is used to process cluster membership events.
-func BlockingNotifier() Notifier {
-	return &notifier{make(chan raftor.ClusterChangeEvent)}
+// NewEventDelegate creates a memberlist.EventDelegate and sends all
+// cluster changes to the given raftor.ClusterChangeNotifier.
+func NewEventDelegate(n raftor.ClusterChangeNotifier) memberlist.EventDelegate {
+	return &notifier{n}
 }
 
-// BufferedNotifier will buffer events up to the size given. After the buffered channel is full it will block until an event has been consumed.
-func BufferedNotifier(size int) Notifier {
-	return &notifier{make(chan raftor.ClusterChangeEvent, size)}
-}
-
-// A Notifier subscribes to memberlist notifications and emits them as raftor.ClusterChangeEvents.
-type Notifier interface {
-	raftor.ClusterChangeNotifier
-	memberlist.EventDelegate
-}
-
-// notifier notifies the receiver of the cluster change.
+// notifier implements the memberlist.EventDelegate interface and forwards
+// all the events to a raftor.ClusterChangeNotifier.
 type notifier struct {
-	channel chan raftor.ClusterChangeEvent
+	n raftor.ClusterChangeNotifier
 }
 
-// NotifyChange sends raftor.ClusterChangeEvents over the given channel when a node joins, leaves or is updated in the cluster.
-func (n *notifier) Notify() <-chan raftor.ClusterChangeEvent {
-	return n.channel
-}
-
-// NotifyJoin is invoked when a node is detected to have joined.
-// The Node argument must not be modified.
+// NotifyJoin is invoked when a node is detected to have joined. A raftor.ClusterChangeEvent
+// is created with the raftor.AddMember type and is sent to the Notifier.
 func (n *notifier) NotifyJoin(other *memberlist.Node) {
-	n.send(raftor.ClusterChangeEvent{
-		Type:   raftor.AddMember,
-		Member: raftor.NewMember(n.hash(other), other.Meta),
-	})
-	return
+	n.send(raftor.AddMember, other)
 }
 
-// NotifyLeave is invoked when a node is detected to have left.
-// The Node argument must not be modified.
+// NotifyLeave is invoked when a node is detected to have left. A raftor.ClusterChangeEvent
+// is created with the raftor.RemoveMember type and is sent to the Notifier.
 func (n *notifier) NotifyLeave(other *memberlist.Node) {
-	n.send(raftor.ClusterChangeEvent{
-		Type:   raftor.RemoveMember,
-		Member: raftor.NewMember(n.hash(other), other.Meta),
-	})
-	return
+	n.send(raftor.RemoveMember, other)
 }
 
 // NotifyUpdate is invoked when a node is detected to have
-// updated, usually involving the meta data. The Node argument
-// must not be modified.
+// updated, usually involving the meta data. A raftor.ClusterChangeEvent
+// is created with the raftor.UpdateMember type and is sent to the Notifier.
 func (n *notifier) NotifyUpdate(other *memberlist.Node) {
-	n.send(raftor.ClusterChangeEvent{
-		Type:   raftor.UpdateMember,
+	n.send(raftor.UpdateMember, other)
+}
+
+// send calls the Notifier to notify it of the cluster change
+func (n *notifier) send(typ raftor.ClusterEventType, other *memberlist.Node) {
+	n.n.Notify(raftor.ClusterChangeEvent{
+		Type:   typ,
 		Member: raftor.NewMember(n.hash(other), other.Meta),
 	})
-	return
 }
 
-// Stop closes the notifier channel
-func (n *notifier) Stop() {
-	close(n.channel)
-}
-
-// send sends an event over the channel
-func (n *notifier) send(evt raftor.ClusterChangeEvent) {
-	n.channel <- evt
-}
-
-// hash performs a Murmur3 hash on the memberlist.Node
+// hash performs a Murmur3 hash on the memberlist.Node name
 func (n *notifier) hash(other *memberlist.Node) uint64 {
 	return uint64(murmur.Murmur3([]byte(other.Name), murmur.M3Seed))
 }

--- a/updater.go
+++ b/updater.go
@@ -1,0 +1,8 @@
+package raftor
+
+// Updater applies cluster change events
+type Updater interface {
+
+	// Update is called after the ClusterChangeEvent has been processed and stored by Raft.
+	Update(ClusterChangeEvent)
+}


### PR DESCRIPTION
- Adding Updater interface for handling cluster change events.
- Updated Applier interface to accept commits via function call instead of a channel.
- Updated Cluster interface to compose Notifier, Applier and Updater interfaces.
- Updated Notifier tests to use new interface.
